### PR TITLE
Fix calculating endIndex of the catalog slice

### DIFF
--- a/shared/lib/src/bloc_complex/catalog/catalog_slice.dart
+++ b/shared/lib/src/bloc_complex/catalog/catalog_slice.dart
@@ -29,8 +29,7 @@ class CatalogSlice {
         hasNext = true;
 
   /// The index of the last product of this slice.
-  int get endIndex =>
-      startIndex + _pages.map((page) => page.endIndex).fold(-1, max);
+  int get endIndex => _pages.map((page) => page.endIndex).fold(-1, max);
 
   /// Returns the product at [index], or `null` if data isn't loaded yet.
   Product elementAt(int index) {


### PR DESCRIPTION
Start index shouldn't be added to the maximum index retrieved from pages.

`endIndex` isn't used anywhere so this bug didn't show up yet in the app.