### PR TITLE
Cut bloc reinit in didUpdateWidget

### DIFF
--- a/shared/lib/src/bloc_complex/product_grid/product_square.dart
+++ b/shared/lib/src/bloc_complex/product_grid/product_square.dart
@@ -23,7 +23,7 @@ class ProductSquare extends StatefulWidget {
   final GestureTapCallback onTap;
 
   ProductSquare({
-    Key key,
+    @required Key key,
     @required this.product,
     @required this.itemsStream,
     this.onTap,
@@ -61,35 +61,32 @@ class _ProductSquareState extends State<ProductSquare> {
     );
   }
 
-  /// Remember: widgets can change from above the [State] at the framework's
-  /// discretion. We need to make sure we always update the [State]
-  /// to reflect the [StatefulWidget].
-  ///
-  /// Here, we're disposing of the old [_bloc] and creating a new one.
+  /// Widgets can change from above the [State] at the framework's
+  /// discretion. But we don't need to update the [State] because the key is specified
   @override
   void didUpdateWidget(ProductSquare oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _disposeBloc();
-    _createBloc();
+//    print(
+//        'didUpdateWidget(old: ${oldWidget.product.id}, current: ${widget.product.id})');
+    assert(widget.product == oldWidget.product,
+        'ProductSquare\'s key is specified, so the same product is keeped always');
   }
 
   @override
   void dispose() {
-    _disposeBloc();
+    _subscription.cancel();
+    _bloc.dispose();
     super.dispose();
   }
 
   /// Initialize business logic components that you will be disposing of in
   /// [initState].
+  ///
+  /// Create the [ProductSquareBloc] and pipe the stream of cart items
+  /// into its [ProductSquareBloc.cartItems] input.
   @override
   void initState() {
     super.initState();
-    _createBloc();
-  }
-
-  /// Create the [ProductSquareBloc] and pipe the stream of cart items
-  /// into its [ProductSquareBloc.cartItems] input.
-  void _createBloc() {
     _bloc = ProductSquareBloc(widget.product);
     _subscription = widget.itemsStream.listen(_bloc.cartItems.add);
   }
@@ -105,10 +102,5 @@ class _ProductSquareState extends State<ProductSquare> {
         decoration: isInCart ? TextDecoration.underline : null,
       ),
     );
-  }
-
-  void _disposeBloc() {
-    _subscription.cancel();
-    _bloc.dispose();
   }
 }


### PR DESCRIPTION
Thanks for the great example 👍 

I investigated the `bloc_complex`, and I found that `widget.product` equals to `oldWidget.product` always in didUpdateWidget.

I think that:

1.  ProductSquare's key is specified from ProductGrid, so each state keeps following the widget which holds same product. So, re-initing the bloc in didUpdateWidget is redundant and moreover it causes performance degradation.
2. And even if the ProductSquare's key is omitted, the result will be same because each ProductSquare's index is keeped, so each state is able to keep following  the widget which holds same product.
    - If items swapped [like this video](https://www.youtube.com/watch?v=kn0EOS-ZiIc&t=244s), widget will be swapped to another which holds different product, but `bloc_complex` doesn't have such features.
    - Although, it is better practice to pass the key to item in GridView, I think.


I'm welcome that this pull request is rejected, but If so I'd like to know an actual procedure to reproduce the case the product is swapped to another one(if it is not occurred, I think current code is redundant).